### PR TITLE
Add method to get the path of the mutool binary

### DIFF
--- a/lib/Alien/MuPDF.pm
+++ b/lib/Alien/MuPDF.pm
@@ -6,6 +6,17 @@ use warnings;
 use parent qw(Alien::Base);
 use File::Spec;
 
+=method mutool_path
+
+Returns a C<Str> which contains the absolute path
+to the C<mutool> binary.
+
+=cut
+sub mutool_path {
+  my ($self) = @_;
+  File::Spec->catfile( $self->dist_dir , 'bin', 'mutool' );
+}
+
 sub inline_auto_include {
 	return  [ 'mupdf/fitz.h' ];
 }

--- a/t/use.t
+++ b/t/use.t
@@ -1,0 +1,22 @@
+use Test::More tests => 2;
+
+use strict;
+use warnings;
+use IPC::Open3;
+
+BEGIN{  use_ok 'Alien::MuPDF' }
+
+my $p = Alien::MuPDF->new;
+
+my($wtr, $rdr, $err);
+use Symbol 'gensym'; $err = gensym;
+my $pid = open3($wtr, $rdr, $err,
+	$p->mutool_path, "-v" );
+# WARN: this could block --- I should use select() or IPC::Run3, but this may work for now
+my $result = join "", <$err>;
+waitpid( $pid, 0 );
+
+like($result, qr/mutool version/, 'can run mutool');
+
+
+done_testing;


### PR DESCRIPTION
Fixes <https://github.com/project-renard/p5-Alien-MuPDF/issues/6>.