### PR TITLE
Fix the path to `mutool` during build-time.

### DIFF
--- a/t/use.t
+++ b/t/use.t
@@ -3,15 +3,20 @@ use Test::More tests => 2;
 use strict;
 use warnings;
 use IPC::Open3;
+use File::Spec;
 
 BEGIN{  use_ok 'Alien::MuPDF' }
 
 my $p = Alien::MuPDF->new;
 
+my $mutool_path = -r $p->mutool_path
+	? $p->mutool_path                    # installed path
+	: File::Spec->catfile( $p->dist_dir, # path when building
+		qw(build release mutool));
 my($wtr, $rdr, $err);
 use Symbol 'gensym'; $err = gensym;
 my $pid = open3($wtr, $rdr, $err,
-	$p->mutool_path, "-v" );
+	$mutool_path, "-v" );
 # WARN: this could block --- I should use select() or IPC::Run3, but this may work for now
 my $result = join "", <$err>;
 waitpid( $pid, 0 );


### PR DESCRIPTION
Before installation, the path to `mutool` is not under `bin/mutool`, but
under `build/release/mutool`.

Fixes <https://github.com/project-renard/p5-Alien-MuPDF/issues/12>.