### PR TITLE
Build: Use Alien::gmake to build on more *nix systems

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,12 +12,13 @@ version = 0.005
 
 [Alien]
 :version = 0.023
+bin_requires = Alien::gmake = 0.14
 repo = http://mupdf.com/downloads/
 pattern = mupdf-([\w\.]+)-source\.tar\.gz
 bins = mutool
 
-build_command = make HAVE_GLFW=no
-install_command = make HAVE_GLFW=no prefix=%s install
+build_command = %{gmake} HAVE_GLFW=no
+install_command = %{gmake} HAVE_GLFW=no prefix=%s install
 # install_command ... 'XCFLAGS=-fPIC' ## in case we want to build a shared library
 
 [AutoPrereqs]


### PR DESCRIPTION
In particular, this allows building on *BSD systems which often do not
have a GNU toolchain and thus do not use GNU make.

Fixes <https://rt.cpan.org/Ticket/Display.html?id=110287>.

Fixes <https://github.com/project-renard/p5-Alien-MuPDF/issues/11>.
