### PR TITLE
Apply patch to remove `HAVE_INCBIN` on FreeBSD systems

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,10 +13,13 @@ version = 0.005_01
 [Alien]
 :version = 0.023
 bin_requires = Alien::gmake = 0.14
+bin_requires = Alien::patch = 0.08
 repo = http://mupdf.com/downloads/
 pattern = mupdf-([\w\.]+)-source\.tar\.gz
 bins = mutool
 
+; Apply patch for issue <https://github.com/project-renard/p5-Alien-MuPDF/issues/15>.
+build_command = %{patch} -p1 < ../../patch/freebsd-no-have-incbin.diff
 build_command = %{gmake} HAVE_GLFW=no
 install_command = %{gmake} HAVE_GLFW=no prefix=%s install
 # install_command ... 'XCFLAGS=-fPIC' ## in case we want to build a shared library

--- a/patch/freebsd-no-have-incbin.diff
+++ b/patch/freebsd-no-have-incbin.diff
@@ -1,0 +1,11 @@
+--- a/scripts/fontdump.c	2016-04-21 06:14:32.000000000 -0500
++++ b/scripts/fontdump.c	2016-08-06 15:07:07.632521751 -0500
+@@ -48,7 +48,7 @@
+ 	}
+ 
+ 	fprintf(fo, "#ifndef __STRICT_ANSI__\n");
+-	fprintf(fo, "#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)\n");
++	fprintf(fo, "#if defined(__linux__) || defined(__OpenBSD__)\n");
+ 	fprintf(fo, "#if !defined(__ICC)\n");
+ 	fprintf(fo, "#define HAVE_INCBIN\n");
+ 	fprintf(fo, "#endif\n");


### PR DESCRIPTION
This patch allows MuPDF to compile on FreeBSD's C compiler.

Patch against mupdf-1.9a.

Related MuPDF issue: <http://bugs.ghostscript.com/show_bug.cgi?id=696828>.

Fixes <https://github.com/project-renard/p5-Alien-MuPDF/issues/16>.