### PR TITLE
Use File::Which to get path to mutool binary in t/use.t

### DIFF
--- a/t/use.t
+++ b/t/use.t
@@ -2,26 +2,24 @@ use Test::More tests => 2;
 
 use strict;
 use warnings;
-use IPC::Open3;
 use File::Spec;
+use File::Which 1.21 qw(which);
+use Capture::Tiny qw(capture_merged);
 
 BEGIN{  use_ok 'Alien::MuPDF' }
 
 my $p = Alien::MuPDF->new;
 
-my $mutool_path = -r $p->mutool_path
-	? $p->mutool_path                    # installed path
-	: File::Spec->catfile( $p->dist_dir, # path when building
+my $mutool_path_in_build =
+	File::Spec->catfile( $p->dist_dir, # path when building
 		qw(build release mutool));
-my($wtr, $rdr, $err);
-use Symbol 'gensym'; $err = gensym;
-my $pid = open3($wtr, $rdr, $err,
-	$mutool_path, "-v" );
-# WARN: this could block --- I should use select() or IPC::Run3, but this may work for now
-my $result = join "", <$err>;
-waitpid( $pid, 0 );
+my $mutool_path = which($mutool_path_in_build)
+	// which($p->mutool_path);             # installed path
+my ($merged, $exit) = capture_merged {
+	system( $mutool_path, qw(-v) );
+};
 
-like($result, qr/mutool version/, 'can run mutool');
+like($merged, qr/mutool version/, 'can run mutool');
 
 
 done_testing;


### PR DESCRIPTION
This allows the path detection to work properly on Windows which appends
the contents of `$ENV{PATHEXT}` to the end of any executed command.
Simply using `-r` on the path does not work.