### PR TITLE
Fix the t/inline.t version number test

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.007
+  - Fix the t/inline.t version number test so that it works with
+    the MuPDF v1.10 release.
+
+    Fixes RT#118882 <https://rt.cpan.org/Ticket/Display.html?id=118882>,
+    <https://github.com/project-renard/p5-Alien-MuPDF/issues/22>.
+    Thanks to SREZIC++ for the bug report.
+
 0.006 2016-08-25 05:52:48-0500
   - Change syntax in test so that it runs on Perl v5.8
     Fixes <https://github.com/project-renard/p5-Alien-MuPDF/issues/20>.

--- a/t/inline.t
+++ b/t/inline.t
@@ -24,7 +24,10 @@ SKIP: {
 		}
 	|, ENABLE => AUTOWRAP => @inc_built);
 
-	like( get_fitz_version(), qr/^\d\.\d[a-z]?$/); # single digits for now, followed by optional letter
+	# single digit for the major version,
+	# multiple digits for the minor version,
+	# followed by optional letter
+	like( get_fitz_version(), qr/^\d\.\d+[a-z]?$/);
 }
 
 done_testing;


### PR DESCRIPTION
Fixes <https://github.com/project-renard/p5-Alien-MuPDF/issues/22>.

Thanks to SREZIC++ (@eserte) for the bug report.