### PR TITLE
Update version regex to match MuPDF v1.12.0

### DIFF
--- a/t/inline.t
+++ b/t/inline.t
@@ -31,8 +31,10 @@ SKIP: {
 
 		# single digit for the major version,
 		# multiple digits for the minor version,
-		# followed by optional letter
-		like( get_fitz_version(), qr/^\d\.\d+[a-z]?$/);
+		#   - followed by
+		#      - optional letter
+		#      - or a dot followed by digits
+		like( get_fitz_version(), qr/^\d+\.\d+([a-z]|\.\d+)?$/);
 	};
 
 	subtest 'Call a function' => sub {


### PR DESCRIPTION
MuPDF v1.12.0 was released 2017-12-13.

Fixes <https://github.com/project-renard/p5-Alien-MuPDF/issues/39>.


